### PR TITLE
Pre Render Methods

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AccretionGeometry"
 uuid = "7f85384a-175b-40eb-971c-1f0b02ab1b9a"
 authors = ["fjebaker <fergusbkr@gmail.com>"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 GeodesicBase = "1f539516-e6d2-4f24-ab09-50f3ac3c4a5a"
@@ -10,3 +10,6 @@ GeodesicTracer = "1f548346-32cf-4117-8ecc-304cf7418187"
 GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+
+[compat]
+GeodesicRendering = ">=0.1.2"

--- a/src/AccretionGeometry.jl
+++ b/src/AccretionGeometry.jl
@@ -1,7 +1,7 @@
 module AccretionGeometry
 
 import GeodesicTracer: tracegeodesics, DiscreteCallback, terminate!
-import GeodesicRendering: rendergeodesics
+import GeodesicRendering: rendergeodesics, prerendergeodesics
 import Base: in
 import RecursiveArrayTools: ArrayPartition
 import GeometryBasics
@@ -47,6 +47,18 @@ function rendergeodesics(
     rendergeodesics(m, init_pos, max_time; callback = cbs, kwargs...)
 end
 
+function prerendergeodesics(
+    m::AbstractMetricParams{T},
+    init_pos,
+    max_time::T,
+    accretion_geometry;
+    callback = nothing,
+    kwargs...,
+) where {T}
+    cbs = add_collision_callback(callback, accretion_geometry)
+    prerendergeodesics(m, init_pos, max_time; callback = cbs, kwargs...)
+end
+
 add_collision_callback(::Nothing, accretion_geometry) =
     build_collision_callback(accretion_geometry)
 add_collision_callback(callback::Base.AbstractVecOrTuple, accretion_geometry) =
@@ -62,6 +74,6 @@ collision_callback(m::AbstractAccretionGeometry{T}) where {T} =
     (u, λ, integrator) -> intersects_geometry(m, line_element(u, integrator))
 
 
-export tracegeodesics, rendergeodesics
+export tracegeodesics, rendergeodesics, prerendergeodesics
 
 end # module


### PR DESCRIPTION
Adds a dispatch for the `prerendergeodesics` method in

- https://github.com/astro-group-bristol/GeodesicRendering.jl/pull/6

which supports geometry.

Todo in the future, add an `apply`-like method for calculating intersection cache from a given render cache.